### PR TITLE
Fix incorrect file open mode in utils/change_dev_size

### DIFF
--- a/utils/change_dev_size.py
+++ b/utils/change_dev_size.py
@@ -29,7 +29,7 @@ def main():
     return -1
 
   f_contents = str()
-  with open(storage_h, "r+b") as f:
+  with open(storage_h, "r+") as f:
     f_contents = f.read()
 
     pattern = r'(^static uint64\_t dev\_size[^{}]*) {[^{}]*}(.*)'


### PR DESCRIPTION
An error was thrown before the change -
TypeError: cannot use a string pattern on a bytes-like object
It occurred because the file is a text file and it has been opened in binary mode.